### PR TITLE
security: fix gosec G301/G304/G204 findings and bump golang.org/x/sys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/sys v0.38.0 // indirect
+require golang.org/x/sys v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
 golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/generator/frontend.go
+++ b/internal/generator/frontend.go
@@ -5,9 +5,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 
 	"github.com/cuesoftinc/open-source-project-generator/pkg/output"
 )
+
+// validAppName restricts generated app names to lowercase letters, digits, and
+// hyphens. This matches npm package naming rules and prevents command injection
+// via untrusted values passed to the "npx" subprocess.
+var validAppName = regexp.MustCompile(`^[a-z0-9-]+$`)
 
 type FrontendGenerator struct {
 	Version    string
@@ -21,7 +27,11 @@ func (g *FrontendGenerator) Generate(projectName string) error {
 
 	for _, app := range g.Apps {
 		appName := projectName + "-" + app
+		if !validAppName.MatchString(appName) {
+			return fmt.Errorf("invalid app name %q: must match %s", appName, `^[a-z0-9-]+$`)
+		}
 
+		// #nosec G204 -- appName is validated against ^[a-z0-9-]+$ above; the command and all remaining arguments are static literals
 		cmd := exec.Command("npx", fmt.Sprintf("create-next-app@%s", g.Version), appName,
 			"--typescript",
 			"--tailwind",

--- a/pkg/config/project.go
+++ b/pkg/config/project.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/cuesoftinc/open-source-project-generator/pkg/constants"
 	"github.com/cuesoftinc/open-source-project-generator/pkg/mapper"
@@ -34,7 +36,14 @@ type Project struct {
 }
 
 func LoadProject(path string) (*Project, error) {
-	data, err := os.ReadFile(path)
+	// Clean the user-supplied path and reject any attempt to traverse to a
+	// parent directory before opening the file (mitigates path inclusion).
+	cleanPath := filepath.Clean(path)
+	if cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(os.PathSeparator)) {
+		return nil, fmt.Errorf("invalid config file path %q: must not reference a parent directory", path)
+	}
+
+	data, err := os.ReadFile(cleanPath) // #nosec G304 -- path is cleaned and validated above to prevent directory traversal
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
@@ -42,6 +51,10 @@ func LoadProject(path string) (*Project, error) {
 	var cfg ProjectConfig
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if err := validateProjectName(cfg.ProjectName); err != nil {
+		return nil, err
 	}
 
 	project := &Project{
@@ -89,4 +102,24 @@ func LoadProject(path string) (*Project, error) {
 	}
 
 	return project, nil
+}
+
+// validateProjectName ensures the configured project name is safe to use as a
+// filesystem path segment and as an argument to external commands. It rejects
+// empty names, parent-directory references, absolute paths, and embedded path
+// separators.
+func validateProjectName(name string) error {
+	if name == "" {
+		return fmt.Errorf("project_name must not be empty")
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("project_name %q must not contain '..'", name)
+	}
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("project_name %q must not be an absolute path", name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("project_name %q must not contain path separators", name)
+	}
+	return nil
 }

--- a/pkg/filesystem/structure.go
+++ b/pkg/filesystem/structure.go
@@ -15,7 +15,7 @@ func CreateProjectStructure(projectPath string, folders []string) error {
 
 	for _, folder := range folders {
 		folderPath := filepath.Join(projectPath, folder)
-		if err := os.MkdirAll(folderPath, 0755); err != nil {
+		if err := os.MkdirAll(folderPath, 0750); err != nil {
 			return fmt.Errorf("failed to create folder %s: %w", folder, err)
 		}
 	}


### PR DESCRIPTION
## Summary

Minimal, behavior-preserving fixes for outstanding security findings (gosec + a transitive dependency CVE). No functional change for legitimate configs (verified against `configs/project.yaml`).

## Changes

- **CVE-2026-39824 — `golang.org/x/sys`**: bumped `0.38.0` → `0.47.0` (fixed in `0.44.0`). Indirect/transitive dependency; `go.mod` and `go.sum` updated via `go get golang.org/x/sys@latest` + `go mod tidy`.
- **G301** (`pkg/filesystem/structure.go:18`): directory permissions tightened from `0755` → `0750` on `os.MkdirAll`.
- **G304** (`pkg/config/project.go`): the config file path is now `filepath.Clean`ed and rejected if it traverses to a parent directory before being read. Also added `validateProjectName` to reject empty names, `..`, absolute paths, and path separators, so unvalidated config values can no longer escape the output directory. A justified `// #nosec G304` documents the validated read.
- **G204** (`internal/generator/frontend.go`): the app name passed to the `npx create-next-app` subprocess is validated against a strict `^[a-z0-9-]+$` allowlist before use, preventing command/argument injection. A justified `// #nosec G204` documents the validation.

## Verification

- `gosec ./...` — **0 issues** (was 3: G301, G304, G204).
- `gofmt -l` — clean on all modified files.
- `go build`/`go vet` could not run in the dev environment due to a Go stdlib toolchain version mismatch (`go1.25.5` vs `go1.26.5`), unrelated to these changes. gosec's own type-checking/package load succeeded, and CI (Test/Build/Security) will validate on the correct toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)