### PR TITLE
docs: present the repo as the standard, drop unused-CLI history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Changed
+### Added
 
-- Transformed the repository from a Go scaffolding CLI into a skill for coding
-  agents: added `SKILL.md` (the CueLABS repository standard plus bootstrap and
-  standardize procedures) and `templates/` (canonical community-health and
-  config file templates).
-- Renamed the repository from `open-source-project-generator` to
-  `oss-engineering-standards`.
-- Established parity: `templates/` now holds the byte-identical community-health
-  files shared across CueLABS repos (LICENSE, CODEOWNERS, CONTRIBUTING,
-  CODE_OF_CONDUCT, SECURITY, .gitignore, .editorconfig, .dockerignore, and
-  PR/issue templates). The `dependabot.example.yml` has no `github-actions`
-  entry (this standard uses no CI workflows).
-
-### Removed
-
-- The Go CLI implementation (`cmd/`, `internal/`, `pkg/`), `go.mod`/`go.sum`,
-  the three Dockerfiles, `docker-compose.yml`, build/version scripts, the stale
-  Go-CLI `Makefile`, and the outdated CLI documentation.
+- `SKILL.md`: the CueLABS repository standard plus bootstrap and standardize
+  procedures for coding agents.
+- `templates/`: canonical community-health and config templates (LICENSE,
+  CODEOWNERS, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, .gitignore, .editorconfig,
+  .dockerignore, a dependabot example, and PR/issue templates), shared
+  byte-identically across CueLABS repositories.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,26 @@
-# CueLABS Project Standard
+# CueLABS Engineering Standards
 
-The canonical repository standard for CueLABS projects, packaged as a **skill for
-coding agents** rather than a CLI.
+The canonical repository standard for CueLABS projects, packaged as a skill for
+coding agents.
 
 ## What this is
 
-This repository used to be a Go scaffolding CLI that generated new projects. Scaffolding, though, is just directory creation, file
-templates, and standard tool invocations (`create-next-app`, `go mod init`, …) —
-all of which a coding agent does directly, and an agent can additionally
-*standardize an existing repo*, which the CLI could not. So the CLI has been
-replaced by:
+This repository defines how CueLABS repositories are structured and provides the
+reusable files to achieve it:
 
 - **[`SKILL.md`](SKILL.md)** — the standard and the procedures (bootstrap a new
   repo; standardize an existing one), for a coding agent to follow.
 - **[`templates/`](templates/)** — reusable file templates: community-health
-  files, a scoped `dependabot.example.yml`, and issue/PR templates. Dotfile
-  templates are stored without the leading dot (copy `dockerignore.root` →
-  `.dockerignore`, `editorconfig` → `.editorconfig`).
+  files, a `dependabot.example.yml`, and issue/PR templates. Dotfile templates
+  are stored without the leading dot (copy `gitignore` → `.gitignore`,
+  `dockerignore.root` → `.dockerignore`, `editorconfig` → `.editorconfig`).
 
 The reference implementation of the standard is **cuesoftinc/apparule**.
 
 ## Usage
 
-Point a coding agent at [`SKILL.md`](SKILL.md) and ask it to either bootstrap a
-new repository or standardize an existing one. The skill defines the directory
+Point a coding agent at [`SKILL.md`](SKILL.md) and ask it to bootstrap a new
+repository or standardize an existing one. The skill defines the directory
 structure, naming rules (`api/common` for the Go backend; other services named
 by function, never by language), required root files, the deploy convention (one
 Helm chart deploys all services including Envoy), recommended versions, and the

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,11 +10,10 @@ description: >-
 # CueLABS Project Standard
 
 This skill encodes how CueLABS repositories are structured so a coding agent can
-**bootstrap a new repo** or **standardize an existing one** consistently. It
-replaces a former Go scaffolding CLI: scaffolding is just
-directory creation, file templates, and standard tool invocations
-(`create-next-app`, `go mod init`, …), all of which an agent does directly — and
-an agent can also refactor an existing repo, which the CLI never could.
+**bootstrap a new repo** or **standardize an existing one** consistently.
+Scaffolding is just directory creation, file templates, and standard tool
+invocations (`create-next-app`, `go mod init`, …), all of which an agent does
+directly — and an agent can also refactor an existing repo in place.
 
 The reference implementation is **cuesoftinc/apparule** — when in doubt, mirror it.
 


### PR DESCRIPTION
Removes all references to the previous (never-used) Go CLI and old repo name from README, SKILL.md, and CHANGELOG. The repo now reads purely as the CueLABS standard + skill.