### PR TITLE
docs: match skill name to repo slug

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cuelabs-engineering-standards
+name: oss-engineering-standards
 description: >-
   The CueLABS repository standard for coding agents. Use when bootstrapping a
   new CueLABS repo or standardizing an existing one (apparule, expendit, upstat,


### PR DESCRIPTION
Skill `name` was `cuelabs-engineering-standards` while the repo is `oss-engineering-standards`. Aligned the identifier to the repo slug.