### PR TITLE
Document port convention + per-language naming standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `SKILL.md`: the CueLABS repository standard plus bootstrap and standardize
   procedures for coding agents.
 - `templates/`: canonical community-health and config templates (LICENSE,
-  CODEOWNERS, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, .gitignore, .editorconfig,
-  .dockerignore, a dependabot example, and PR/issue templates), shared
-  byte-identically across CueLABS repositories.
+  CODEOWNERS, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, dotfile templates stored
+  without the leading dot — `gitignore`, `editorconfig`, `dockerignore.root` —
+  a dependabot example, and PR/issue templates), shared byte-identically across
+  CueLABS repositories.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Port convention (`api/common`=8080, `web`=3000, additional APIs increment from
+  8081) and a per-language file & folder naming standard in `SKILL.md`.
 - `SKILL.md`: the CueLABS repository standard plus bootstrap and standardize
   procedures for coding agents.
 - `templates/`: canonical community-health and config templates (LICENSE,
   CODEOWNERS, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, .gitignore, .editorconfig,
   .dockerignore, a dependabot example, and PR/issue templates), shared
   byte-identically across CueLABS repositories.
+
+### Changed
+
+- Refined the production service-structure guidance (singular Go packages,
+  FastAPI `lifespan`, web `src/` + route conventions) and synced the `Makefile`,
+  `Dockerfile.go`, `Dockerfile.web`, and `docker-compose.example.yml` templates.

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,9 +50,9 @@ service exists — do not add empty `api/image` placeholders.
 
 **These files must have parity across all CueLABS repos** — byte-identical,
 sourced from [`templates/`](templates/). Only `README.md`, `CHANGELOG.md`,
-`Makefile`, and `.github/dependabot.yml` are repo-specific (repo overview, its
-own history, its own build targets, and its own manifest scoping); everything
-else in the table below is identical across repos.
+and `.github/dependabot.yml` are repo-specific (repo overview, its own history,
+and its own manifest scoping); everything else in the table below — including the
+compose-driven `Makefile` — is identical across repos.
 
 | File | Purpose |
 |------|---------|
@@ -66,14 +66,15 @@ else in the table below is identical across repos.
 | `.gitignore` | Must NOT ignore `.dockerignore`; must ignore `.env*`, secrets |
 | `.dockerignore` | Root + one per build context; exclude `.env`/secrets/artifacts |
 | `.editorconfig` | Shared editor settings (tabs for Go) |
-| `Makefile` | Common tasks across services |
+| `Makefile` | Compose-driven standard targets (up/down/build/logs/…); identical across repos |
 | `.github/dependabot.yml` | **Scoped per manifest**, grouped per ecosystem |
 | `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist |
 | `.github/ISSUE_TEMPLATE/` | bug_report, feature_request, config.yml |
 
 **What's in `templates/`:** ready-to-copy `LICENSE`, `CODEOWNERS`,
 `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `PULL_REQUEST_TEMPLATE.md`,
-`ISSUE_TEMPLATE/*`, and a `dependabot.example.yml`. Dotfile templates are stored
+`ISSUE_TEMPLATE/*`, `Makefile`, a `dependabot.example.yml`, and Docker templates
+(`Dockerfile.go`, `Dockerfile.web`, `docker-compose.example.yml`). Dotfile templates are stored
 **without** a leading dot so they stay visible and are never applied to this repo
 by accident — when adopting them, copy `templates/gitignore` → `.gitignore`,
 `templates/dockerignore.root` → `.dockerignore`, and `templates/editorconfig` →
@@ -86,10 +87,90 @@ ecosystem, and **must not** point at dead/deprecated directories. It has **no**
 `github-actions` entry — this standard uses no CI workflows, so that updater
 would fail with "no workflows found".
 
+## Service structure (production)
+When bootstrapping or standardizing a service, **migrate existing code into
+these layouts** — don't scaffold empty projects.
+
+**Go (`api/common`):**
+```
+cmd/server/main.go            entrypoint: slog JSON, config → deps → graceful shutdown
+internal/config/              typed env config (fail-fast on missing secrets)
+internal/handler/             thin HTTP/gRPC handlers
+internal/middleware/          slog logging, request-id, CORS allowlist, recovery
+internal/model/  internal/service/  internal/repository/  internal/router/
+internal/util/   internal/proto/ (generated)
+```
+Singular package names. `/health` + `/ready`, `$PORT` (8080), structured `slog`,
+graceful shutdown on SIGINT/SIGTERM. gRPC services multiplex gRPC + `/health`
+over `$PORT` via h2c.
+
+**Python (`api/<service>`, FastAPI):**
+```
+app/main.py app/config.py     FastAPI + lifespan (load models/clients once)
+router/  service/  model/  repository/   (+ domain pkgs, e.g. ml/, analysis/, database/)
+```
+Singular folders. `lifespan` (never `@app.on_event`), `/health` + `/ready`, uvicorn,
+non-root image, pinned deps.
+
+**Next.js (`web`):**
+```
+src/app/                      routes — home at `/`, product dashboard at `/dashboard`
+src/{components,lib,hooks,types,config,context}   src/proto/ (generated grpc-web, verbatim)
+```
+Minimal root `layout.tsx` (html/body + styled-components registry); the home page
+renders its own shell; `/dashboard` gets a nested `layout.tsx`. `@/*` → `./src/*`,
+`output: "standalone"`.
+
+**Flutter (`mobile/flutter`):**
+```
+lib/main.dart
+lib/src/features/<feature>/   lib/src/core/{theme,localization}
+lib/src/services/  lib/src/shared/{,model}   lib/l10n/ (generated — stays)
+```
+Prefer `package:` imports over relative so moves are mechanical.
+
+### File & folder naming (uniform across repos)
+Same language ⇒ same conventions; each project keeps its own *features*.
+
+| Language | Folders | Files |
+|----------|---------|-------|
+| Go | lowercase, **singular** package (`handler`, `service`, `model`, `repository`, `router`, `util`, `config`, `middleware`, `proto`) | `snake_case.go` |
+| Python | lowercase, **singular** (`router`, `service`, `model`, `repository`) | `snake_case.py` |
+| Next / TS | **kebab-case** (`shared-layouts/`, `change-password/`) | **Components PascalCase** (`NavBar.tsx`); modules/hooks/styles/types **kebab-case** (`use-auth.ts`, `home-context.ts`, `nav-bar.styles.ts`); Next reserved lowercase (`page.tsx`, `layout.tsx`, `route.ts`) |
+| Dart | `snake_case` | `snake_case.dart` |
+
+Generated code (`proto/`, `*_pb.*`, grpc-web clients) keeps its generated names — never rename it.
+
 ## Deploy convention
 A single `deploy/helm` chart deploys **all** services — including the Envoy
 gRPC-Web proxy where used — into a Kubernetes cluster. Do **not** create a
 standalone `deploy/envoy/`; Envoy config lives inside the Helm chart.
+
+## Local development (Docker)
+Each repo has a root `docker-compose.yml` and a compose-driven `Makefile`
+(`make up` / `make down` / `make logs` / `make build`). Copy `.env.example` →
+`.env` first. Service packaging (see `templates/Dockerfile.go`,
+`templates/Dockerfile.web`, `templates/docker-compose.example.yml`):
+
+- **Go services** — multi-stage, static binary (`CGO_ENABLED=0`), non-root user,
+  honors `$PORT` (default 8080), `/health` HEALTHCHECK.
+- **Next.js web** — `output: "standalone"` + multi-stage build that runs
+  `node server.js` as the non-root `node` user (never `npm run dev` in an image).
+
+**Port convention (parity across repos):** so muscle memory carries between
+services, every repo publishes the same host ports — `api/common` → **8080**,
+`web` → **3000**, and each additional API increments from there (**8081**, 8082, …;
+e.g. apparule's `api/measure` → 8081). Compose sets `PORT` and the published port
+to the same value, and the web image's `NEXT_PUBLIC_BASE_URL` build arg targets
+`http://localhost:8080`.
+
+Gotchas that cost real time:
+- Build the web image on **`node:*-slim` (glibc), not Alpine** — Next 16's
+  Turbopack build workers are unreliable on musl.
+- Keep **TypeScript on 5.x**; Next's build-time TS check crashes on the
+  TypeScript 7 native compiler. Dependabot npm-group PRs can silently bump
+  `typescript`/`eslint`/`@types/node` to breaking majors — pin them.
+- `NEXT_PUBLIC_*` are inlined at build time → pass them as Docker build args.
 
 ## Cleanup rules (when standardizing)
 Remove (safe — not application code):

--- a/templates/Dockerfile.go
+++ b/templates/Dockerfile.go
@@ -9,7 +9,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o app ./cmd/server
 
 # ---- runtime ----
-FROM alpine:latest
+FROM alpine:3.20
 RUN adduser -D -u 10001 appuser
 WORKDIR /app
 COPY --from=builder /app/app .

--- a/templates/Dockerfile.go
+++ b/templates/Dockerfile.go
@@ -1,0 +1,20 @@
+# Production Dockerfile for a Go service (build context = the service dir, e.g. api/common).
+# ---- build ----
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o app .
+
+# ---- runtime ----
+FROM alpine:latest
+RUN adduser -D -u 10001 appuser
+WORKDIR /app
+COPY --from=builder /app/app .
+USER appuser
+# Honor $PORT (Cloud Run); the app should default to 8080 locally.
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- "http://localhost:${PORT:-8080}/health" || exit 1
+CMD ["./app"]

--- a/templates/Dockerfile.go
+++ b/templates/Dockerfile.go
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 go build -o app ./cmd/server
 
 # ---- runtime ----
 FROM alpine:3.20
-RUN adduser -D -u 10001 appuser
+RUN apk add --no-cache ca-certificates && adduser -D -u 10001 appuser
 WORKDIR /app
 COPY --from=builder /app/app .
 USER appuser

--- a/templates/Dockerfile.go
+++ b/templates/Dockerfile.go
@@ -19,5 +19,5 @@ USER appuser
 # (8081, 8082, … per the port convention), set EXPOSE to that service's port.
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- "http://localhost:${PORT:-8080}/health" || exit 1
+  CMD wget -qO- "http://127.0.0.1:${PORT:-8080}/health" || exit 1
 CMD ["./app"]

--- a/templates/Dockerfile.go
+++ b/templates/Dockerfile.go
@@ -1,6 +1,6 @@
 # Production Dockerfile for a Go service (build context = the service dir, e.g. api/common).
 # ---- build ----
-FROM golang:1.26-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/templates/Dockerfile.go
+++ b/templates/Dockerfile.go
@@ -2,10 +2,11 @@
 # ---- build ----
 FROM golang:1.26-alpine AS builder
 WORKDIR /app
-COPY go.mod go.sum* ./
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o app .
+# Entrypoint per the standard layout (cmd/server/main.go).
+RUN CGO_ENABLED=0 go build -o app ./cmd/server
 
 # ---- runtime ----
 FROM alpine:latest

--- a/templates/Dockerfile.go
+++ b/templates/Dockerfile.go
@@ -15,6 +15,8 @@ WORKDIR /app
 COPY --from=builder /app/app .
 USER appuser
 # Honor $PORT (Cloud Run); the app should default to 8080 locally.
+# EXPOSE is metadata only — when adapting this template for an additional API
+# (8081, 8082, … per the port convention), set EXPOSE to that service's port.
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget -qO- "http://localhost:${PORT:-8080}/health" || exit 1

--- a/templates/Dockerfile.web
+++ b/templates/Dockerfile.web
@@ -1,0 +1,37 @@
+# Production Dockerfile for the Next.js web app (build context = web/).
+# Requires `output: "standalone"` in next.config.
+#
+# IMPORTANT (learned the hard way):
+#   - Use node:*-slim (Debian/glibc). Next's Turbopack build workers are
+#     unreliable on Alpine/musl.
+#   - Keep TypeScript on 5.x. Next's build-time TS check crashes on the
+#     TypeScript 7 native compiler. Watch out for Dependabot npm-group PRs
+#     sweeping in TS/eslint majors.
+#   - NEXT_PUBLIC_* are inlined at build time, so pass them as build args.
+# ---- deps ----
+FROM node:24-slim AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# ---- builder ----
+FROM node:24-slim AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ARG NEXT_PUBLIC_BASE_URL
+ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+RUN npm run build
+
+# ---- runner ----
+FROM node:24-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production PORT=3000 HOSTNAME=0.0.0.0
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+USER node
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:3000/',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"
+CMD ["node", "server.js"]

--- a/templates/Dockerfile.web
+++ b/templates/Dockerfile.web
@@ -33,5 +33,5 @@ COPY --from=builder --chown=node:node /app/.next/static ./.next/static
 USER node
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3000/',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"
+  CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||3000)+'/',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"
 CMD ["node", "server.js"]

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help up down build rebuild logs ps restart clean
 
 help: ## List available targets
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN{FS=":.*?## "};{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN{FS=":.*## "};{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
 
 up: ## Build and start the full stack (detached)
 	docker compose up --build -d

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,0 +1,31 @@
+# CueLABS standard Makefile — compose-driven local development.
+# Run `make help` to list targets.
+.DEFAULT_GOAL := help
+.PHONY: help up down build rebuild logs ps restart clean
+
+help: ## List available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN{FS=":.*?## "};{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+up: ## Build and start the full stack (detached)
+	docker compose up --build -d
+
+down: ## Stop and remove the stack
+	docker compose down
+
+build: ## Build all service images
+	docker compose build
+
+rebuild: ## Rebuild images from scratch (no cache)
+	docker compose build --no-cache
+
+logs: ## Follow logs from all services
+	docker compose logs -f
+
+ps: ## Show service status
+	docker compose ps
+
+restart: ## Restart all services
+	docker compose restart
+
+clean: ## Stop the stack and remove volumes + orphans
+	docker compose down -v --remove-orphans

--- a/templates/docker-compose.example.yml
+++ b/templates/docker-compose.example.yml
@@ -1,0 +1,27 @@
+# Example local stack. Copy to repo root as docker-compose.yml and adapt
+# services to the repo. `make up` runs `docker compose up --build -d`.
+services:
+  api-common:
+    build: ./api/common
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+    restart: unless-stopped
+
+  # Add one block per additional service that exists, e.g. api/<service>:
+  # api-<service>:
+  #   build: ./api/<service>
+  #   ...
+
+  web:
+    build:
+      context: ./web
+      args:
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:8080}
+    ports:
+      - "3000:3000"
+    depends_on:
+      api-common:
+        condition: service_healthy
+    restart: unless-stopped

--- a/templates/docker-compose.example.yml
+++ b/templates/docker-compose.example.yml
@@ -21,6 +21,8 @@ services:
         NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:8080}
     ports:
       - "3000:3000"
+    environment:
+      PORT: "3000"
     depends_on:
       api-common:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Documents the conventions applied across the CueLABS repos (apparule / expendit / upstat) so future work stays uniform.

- **Port convention** — `api/common` → 8080, `web` → 3000, each additional API increments from **8081**; compose maps `PORT` and the published port to the same value.
- **File & folder naming** (new table) —
  | Language | Folders | Files |
  |---|---|---|
  | Go | lowercase **singular** package | `snake_case.go` |
  | Python | lowercase **singular** | `snake_case.py` |
  | Next/TS | **kebab-case** | **PascalCase** components; **kebab-case** modules; Next reserved lowercase |
  | Dart | `snake_case` | `snake_case.dart` |
- **Service structure** refined: singular Go packages under `internal/`, FastAPI `lifespan` + `/health` + `/ready`, web `src/` with home `/` and dashboard `/dashboard`.
- Synced templates (Makefile, Dockerfile.go, Dockerfile.web, docker-compose.example.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
