### PR TITLE
Audit round: new templates (python/helm/terraform/env) + SKILL coverage sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ labels: [bug]
 A clear and concise description of the bug.
 
 ## Affected area
-`api/common` / `api/<service>` / `web` / `mobile` / `deploy` / other
+`SKILL.md` / `templates/` / other
 
 ## Steps to reproduce
 1.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,6 +14,6 @@ Describe the change you'd like.
 ## Alternatives considered
 
 ## Affected area
-`api/common` / `api/<service>` / `web` / `mobile` / `deploy` / other
+`SKILL.md` / `templates/` / other
 
 ## Additional context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- `templates/Dockerfile.python`, per-context `templates/dockerignore.{go,web,python}`,
+  `templates/env.example`, standard-form Helm chart skeleton (`templates/helm/`),
+  and cluster-agnostic terraform (`templates/terraform/`).
+
+### Changed
+- SKILL.md: per-service internals standard (README/.gitignore/.dockerignore/
+  .env.example per service), canonical Go module paths, SSR-safety and
+  127.0.0.1-healthcheck gotchas, envoy-in-compose pattern, standard-form
+  Helm/terraform deploy convention, scoped `.dockerignore` parity claim, and
+  several accuracy fixes (docs/ list, data stores, root-layout wording).
+- PR template: dropped the CI reference (the standard has no CI workflows).
+
+### Added
 
 - Port convention (`api/common`=8080, `web`=3000, additional APIs increment from
   8081) and a per-language file & folder naming standard in `SKILL.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `templates/Dockerfile.python`, per-context `templates/dockerignore.{go,web,python}`,
   `templates/env.example`, standard-form Helm chart skeleton (`templates/helm/`),
   and cluster-agnostic terraform (`templates/terraform/`).
-
-### Changed
-- SKILL.md: per-service internals standard (README/.gitignore/.dockerignore/
-  .env.example per service), canonical Go module paths, SSR-safety and
-  127.0.0.1-healthcheck gotchas, envoy-in-compose pattern, standard-form
-  Helm/terraform deploy convention, scoped `.dockerignore` parity claim, and
-  several accuracy fixes (docs/ list, data stores, root-layout wording).
-- PR template: dropped the CI reference (the standard has no CI workflows).
-
-### Added
-
 - Port convention (`api/common`=8080, `web`=3000, additional APIs increment from
   8081) and a per-language file & folder naming standard in `SKILL.md`.
 - `SKILL.md`: the CueLABS repository standard plus bootstrap and standardize
@@ -37,3 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Refined the production service-structure guidance (singular Go packages,
   FastAPI `lifespan`, web `src/` + route conventions) and synced the `Makefile`,
   `Dockerfile.go`, `Dockerfile.web`, and `docker-compose.example.yml` templates.
+
+### Changed
+- SKILL.md: per-service internals standard (README/.gitignore/.dockerignore/
+  .env.example per service), canonical Go module paths, SSR-safety and
+  127.0.0.1-healthcheck gotchas, envoy-in-compose pattern, standard-form
+  Helm/terraform deploy convention, scoped `.dockerignore` parity claim, and
+  several accuracy fixes (docs/ list, data stores, root-layout wording).
+- PR template: dropped the CI reference (the standard has no CI workflows).
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cleanup rules.
 ```
 SKILL.md        The standard + bootstrap/standardize procedures
 templates/      Reusable file templates
-.github/        Issue and pull-request templates for this repo
+.github/        Issue templates and Dependabot config for this repo
 ```
 
 Plus the usual community-health files: `LICENSE`, `CONTRIBUTING.md`,

--- a/SKILL.md
+++ b/SKILL.md
@@ -164,6 +164,14 @@ liveness+readiness probes (`healthPath`/`readyPath`, tcp fallback),
 `.Files.Get` in a ConfigMap. Always `helm lint` + `helm template` before
 shipping.
 
+Chart gotchas that cost real time:
+- Pods run `runAsNonRoot` with a **numeric** `runAsUser` (default 10001;
+  web images run as `node` = 1000, Envoy as 101) — kubelet cannot verify
+  named users and rejects the pod otherwise.
+- **Bump `Chart.yaml` version on every chart change** — the terraform helm
+  provider does not upgrade local charts whose version is unchanged.
+- Images live under the `cuesoft` Docker Hub org: `cuesoft/<repo>-<service>`.
+
 `deploy/terraform` (see `templates/terraform/`) is **cluster-agnostic**: the
 helm provider authenticates via kubeconfig (`kubeconfig_path`/`kube_context`
 variables) and installs the repo chart — no cloud-specific providers.

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,10 +31,10 @@ mobile/
   android/           Native Android (Kotlin) — placeholder until built
   ios/               Native iOS (Swift) — placeholder until built
 deploy/
-  docker/            Container / compose configuration
-  helm/              ONE chart that deploys ALL services (incl. Envoy) to k8s
-  terraform/         Infrastructure as code
-docs/                overview.md, setup.md, api/, ui/
+  docker/            Extra container assets (compose itself lives at the repo root)
+  helm/              ONE standard-form chart that deploys ALL services (incl. Envoy) to k8s
+  terraform/         Cluster-agnostic IaC: installs the Helm chart via kubeconfig
+docs/                overview.md, setup.md (+ optional api/, architecture.md)
 scripts/             Developer / CI helper scripts
 ```
 
@@ -64,17 +64,20 @@ compose-driven `Makefile` — is identical across repos.
 | `CHANGELOG.md` | Keep a Changelog format |
 | `LICENSE` | Project license |
 | `.gitignore` | Must NOT ignore `.dockerignore`; must ignore `.env*`, secrets |
-| `.dockerignore` | Root + one per build context; exclude `.env`/secrets/artifacts |
+| `.dockerignore` | Root byte-identical; plus one per build context (repo-specific, see `templates/dockerignore.*`) |
 | `.editorconfig` | Shared editor settings (tabs for Go) |
 | `Makefile` | Compose-driven standard targets (up/down/build/logs/…); identical across repos |
+| `.env.example` | Root env template: per-service sections, dev-safe defaults, `NEXT_PUBLIC_*` block |
 | `.github/dependabot.yml` | **Scoped per manifest**, grouped per ecosystem |
 | `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist |
 | `.github/ISSUE_TEMPLATE/` | bug_report, feature_request, config.yml |
 
 **What's in `templates/`:** ready-to-copy `LICENSE`, `CODEOWNERS`,
 `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `PULL_REQUEST_TEMPLATE.md`,
-`ISSUE_TEMPLATE/*`, `Makefile`, a `dependabot.example.yml`, and Docker templates
-(`Dockerfile.go`, `Dockerfile.web`, `docker-compose.example.yml`). Dotfile templates are stored
+`ISSUE_TEMPLATE/*`, `Makefile`, a `dependabot.example.yml`, an `env.example`,
+Docker templates (`Dockerfile.go`, `Dockerfile.web`, `Dockerfile.python`,
+`docker-compose.example.yml`, per-context `dockerignore.*`), the standard-form
+Helm chart skeleton (`helm/`), and cluster-agnostic terraform (`terraform/`). Dotfile templates are stored
 **without** a leading dot so they stay visible and are never applied to this repo
 by accident — when adopting them, copy `templates/gitignore` → `.gitignore`,
 `templates/dockerignore.root` → `.dockerignore`, and `templates/editorconfig` →
@@ -90,6 +93,12 @@ would fail with "no workflows found".
 ## Service structure (production)
 When bootstrapping or standardizing a service, **migrate existing code into
 these layouts** — don't scaffold empty projects.
+
+**Every service directory** (each `api/*`, `web`) carries its own internals,
+consistent across repos: `README.md` (layout/run/config/test), `.gitignore`,
+`.dockerignore` (see `templates/dockerignore.*`), and `.env.example` with the
+service's native-run variables (compose users rely on the root `.env`).
+Go module paths are canonical: `github.com/cuesoftinc/<repo>/api/common`.
 
 **Go (`api/common`):**
 ```
@@ -117,7 +126,8 @@ non-root image, pinned deps.
 src/app/                      routes — home at `/`, product dashboard at `/dashboard`
 src/{components,lib,hooks,types,config,context}   src/proto/ (generated grpc-web, verbatim)
 ```
-Minimal root `layout.tsx` (html/body + styled-components registry); the home page
+Minimal root `layout.tsx` (html/body — plus a CSS-in-JS registry only where the
+repo uses one); the home page
 renders its own shell; `/dashboard` gets a nested `layout.tsx`. `@/*` → `./src/*`,
 `output: "standalone"`.
 
@@ -146,6 +156,18 @@ A single `deploy/helm` chart deploys **all** services — including the Envoy
 gRPC-Web proxy where used — into a Kubernetes cluster. Do **not** create a
 standalone `deploy/envoy/`; Envoy config lives inside the Helm chart.
 
+The chart is standard-form (see `templates/helm/`): split
+`deployment.yaml`/`service.yaml` ranging over a `services:` values map,
+`_helpers.tpl` with the k8s recommended labels (name/instance/part-of/chart),
+liveness+readiness probes (`healthPath`/`readyPath`, tcp fallback),
+`runAsNonRoot`, `resources`, and `NOTES.txt`. Envoy's config is embedded via
+`.Files.Get` in a ConfigMap. Always `helm lint` + `helm template` before
+shipping.
+
+`deploy/terraform` (see `templates/terraform/`) is **cluster-agnostic**: the
+helm provider authenticates via kubeconfig (`kubeconfig_path`/`kube_context`
+variables) and installs the repo chart — no cloud-specific providers.
+
 ## Local development (Docker)
 Each repo has a root `docker-compose.yml` and a compose-driven `Makefile`
 (`make up` / `make down` / `make logs` / `make build`). Copy `.env.example` →
@@ -156,6 +178,13 @@ Each repo has a root `docker-compose.yml` and a compose-driven `Makefile`
   honors `$PORT` (default 8080), `/health` HEALTHCHECK.
 - **Next.js web** — `output: "standalone"` + multi-stage build that runs
   `node server.js` as the non-root `node` user (never `npm run dev` in an image).
+- **Python services** — `templates/Dockerfile.python`: `python:3.12-slim`,
+  non-root uid 10001, PORT-aware 127.0.0.1 `/health` healthcheck with a long
+  start period (model loads), `uvicorn app.main:app`.
+- **gRPC-Web repos** — run Envoy in compose (image pinned, config mounted from
+  `deploy/helm/envoy/envoy.yaml`, backend network-aliased to the cluster
+  target); Envoy takes the next port slot (e.g. upstat :8082) and the web image
+  gets `NEXT_PUBLIC_ENVOY_URL` as a build arg.
 
 **Port convention (parity across repos):** so muscle memory carries between
 services, every repo publishes the same host ports — `api/common` → **8080**,
@@ -171,6 +200,12 @@ Gotchas that cost real time:
   TypeScript 7 native compiler. Dependabot npm-group PRs can silently bump
   `typescript`/`eslint`/`@types/node` to breaking majors — pin them.
 - `NEXT_PUBLIC_*` are inlined at build time → pass them as Docker build args.
+- **SSR safety**: never touch `localStorage`/`window` during render — only in
+  `useEffect`/handlers (or behind `typeof window !== "undefined"`); prerender
+  crashes otherwise. Session state that both client and shell components need
+  belongs in cookies, written and read by the same names.
+- All healthchecks (web and APIs) target `127.0.0.1`, never `localhost`
+  (IPv6 resolution causes false-unhealthy containers).
 
 ## Cleanup rules (when standardizing)
 Remove (safe — not application code):
@@ -219,7 +254,7 @@ web + dashboard (Next.js) ─┐             api/common (Go)  ── GCP Cloud R
                            ├─ Firebase /  api/<svc> (Python/…) ── Cloud Run
 flutter mobile ────────────┘  Google auth
                                          data: Firebase Firestore & Storage,
-                                               Aiven Postgres & Valkey (Redis)
+                                               Firebase (apparule), MongoDB (+ Redis) elsewhere
 ```
 - Auth: Firebase Authentication / Google sign-in.
 - Backends deploy to GCP Cloud Run (and/or the Helm chart for k8s).
@@ -234,7 +269,7 @@ Keep current; last reviewed with the values below.
 | Go | 1.25+ — builder image matches the module's `go` directive (`golang:1.25-alpine`; apparule is on 1.26) |
 | Gin | v1.12 |
 | Node | 24 (`node:24-slim` images) |
-| Android (Kotlin / Gradle / compileSdk) | 2.2 / 9.1 / 36 |
+| Android (Kotlin / Gradle / compileSdk) | 2.2 / 9.1 / 36 — for future native apps |
 | Python | 3.12 (`python:3.12-slim` images) |
 
 Pin exact versions in each service's manifest; let Dependabot (scoped, grouped)

--- a/templates/Dockerfile.python
+++ b/templates/Dockerfile.python
@@ -1,0 +1,19 @@
+# Production Dockerfile for a Python FastAPI service (build context = the service dir).
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+COPY . .
+RUN useradd -m -u 10001 appuser && chown -R appuser /app
+USER appuser
+
+# Set to the service's port per the convention (8081, 8082, ... for additional APIs).
+ENV PORT=8081
+EXPOSE 8081
+# Long start-period accommodates model loading; probe honors $PORT.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD python -c "import os,urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('PORT','8081')+'/health').status==200 else 1)"
+CMD ["sh","-c","uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8081}"]

--- a/templates/PULL_REQUEST_TEMPLATE.md
+++ b/templates/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 - [ ] `api/<service>`
 - [ ] `web`
 - [ ] `mobile`
-- [ ] `deploy` / CI
+- [ ] `deploy`
 
 ## Checklist
 - [ ] I followed the Contributing guide.

--- a/templates/docker-compose.example.yml
+++ b/templates/docker-compose.example.yml
@@ -3,6 +3,7 @@
 services:
   api-common:
     build: ./api/common
+    image: cuesoft/REPO-api-common:latest
     ports:
       - "8080:8080"
     environment:
@@ -15,6 +16,7 @@ services:
   #   ...
 
   web:
+    image: cuesoft/REPO-web:latest
     build:
       context: ./web
       args:

--- a/templates/dockerignore.go
+++ b/templates/dockerignore.go
@@ -1,0 +1,5 @@
+.env
+.env.*
+*.md
+tmp/
+*.log

--- a/templates/dockerignore.python
+++ b/templates/dockerignore.python
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+tests/
+.env
+.env.*
+*.md

--- a/templates/dockerignore.web
+++ b/templates/dockerignore.web
@@ -1,0 +1,5 @@
+node_modules
+.next
+.env
+.env.*
+*.md

--- a/templates/env.example
+++ b/templates/env.example
@@ -1,0 +1,8 @@
+# Copy to .env for local development: cp .env.example .env
+# Datastore URLs are set to in-cluster service names in docker-compose.yml.
+
+# --- api/common ---
+JWT_SECRET=dev-secret-change-me
+
+# --- web (build-time, inlined into the image) ---
+NEXT_PUBLIC_BASE_URL=http://localhost:8080

--- a/templates/helm/templates/NOTES.txt
+++ b/templates/helm/templates/NOTES.txt
@@ -1,0 +1,9 @@
+{{ .Chart.Name }} deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Services:
+{{- range $name, $svc := .Values.services }}
+  - {{ $name }} (ClusterIP :{{ $svc.port }})
+{{- end }}
+
+Port-forward the web UI:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/web 3000:3000

--- a/templates/helm/templates/_helpers.tpl
+++ b/templates/helm/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{/* Chart-wide labels (k8s recommended label set) */}}
+{{- define "chart.labels" -}}
+app.kubernetes.io/part-of: {{ .Chart.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end }}
+
+{{/* Per-service selector labels; expects (dict "name" <svc> "root" $) */}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ .name }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+{{- end }}

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        # Numeric UID so kubelet can verify non-root (named users fail validation).
+        runAsUser: {{ $svc.runAsUser | default 10001 }}
       containers:
         - name: {{ $name }}
           image: {{ $svc.image }}

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -1,0 +1,72 @@
+{{- range $name, $svc := .Values.services }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "chart.selectorLabels" (dict "name" $name "root" $) | nindent 4 }}
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  replicas: {{ $svc.replicaCount | default $.Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" (dict "name" $name "root" $) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "chart.selectorLabels" (dict "name" $name "root" $) | nindent 8 }}
+        {{- include "chart.labels" $ | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: {{ $name }}
+          image: {{ $svc.image }}
+          imagePullPolicy: {{ $svc.imagePullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: http
+              containerPort: {{ $svc.port }}
+            {{- range $svc.extraPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+            {{- end }}
+          {{- with $svc.env }}
+          env:
+            {{- range $k, $v := . }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if $svc.healthPath }}
+          livenessProbe:
+            httpGet:
+              path: {{ $svc.healthPath }}
+              port: http
+          readinessProbe:
+            httpGet:
+              path: {{ $svc.readyPath | default $svc.healthPath }}
+              port: http
+          {{- else }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
+          {{- end }}
+          resources:
+            {{- toYaml ($svc.resources | default dict) | nindent 12 }}
+          {{- if $svc.envoyConfig }}
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy
+              readOnly: true
+          {{- end }}
+      {{- if $svc.envoyConfig }}
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: {{ $.Chart.Name }}-envoy-config
+      {{- end }}
+{{- end }}

--- a/templates/helm/templates/service.yaml
+++ b/templates/helm/templates/service.yaml
@@ -1,0 +1,25 @@
+{{- range $name, $svc := .Values.services }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "chart.selectorLabels" (dict "name" $name "root" $) | nindent 4 }}
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  selector:
+    {{- include "chart.selectorLabels" (dict "name" $name "root" $) | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $svc.port }}
+      targetPort: http
+      {{- if $svc.h2c }}
+      appProtocol: kubernetes.io/h2c
+      {{- end }}
+    {{- range $svc.extraPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .name }}
+    {{- end }}
+{{- end }}

--- a/templates/helm/values.example.yaml
+++ b/templates/helm/values.example.yaml
@@ -1,0 +1,22 @@
+# Example values for the standard-form chart (copy per repo as values.yaml).
+# Image org on Docker Hub is `cuesoft` — images are cuesoft/<repo>-<service>.
+replicaCount: 1
+
+services:
+  api-common:
+    image: cuesoft/REPO-api-common:latest
+    port: 8080
+    healthPath: /health
+    readyPath: /ready
+    # h2c: true            # gRPC + HTTP multiplexed on one port
+    # runAsUser: 10001     # numeric UID (default 10001; web images use 1000, envoy 101)
+    env:
+      PORT: "8080"
+
+  web:
+    image: cuesoft/REPO-web:latest
+    port: 3000
+    runAsUser: 1000
+    healthPath: /
+    env:
+      PORT: "3000"

--- a/templates/terraform/main.tf
+++ b/templates/terraform/main.tf
@@ -4,4 +4,5 @@ resource "helm_release" "REPO" {
   namespace        = var.namespace
   create_namespace = true
   chart            = "${path.module}/../helm"
+  values           = var.chart_values
 }

--- a/templates/terraform/main.tf
+++ b/templates/terraform/main.tf
@@ -1,0 +1,7 @@
+# Deploys the repo's Helm chart (deploy/helm) — one chart deploys all services.
+resource "helm_release" "REPO" {
+  name             = "REPO"
+  namespace        = var.namespace
+  create_namespace = true
+  chart            = "${path.module}/../helm"
+}

--- a/templates/terraform/outputs.tf
+++ b/templates/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  description = "Namespace the release was installed into."
+  value       = helm_release.REPO.namespace
+}
+
+output "release_status" {
+  description = "Status of the Helm release."
+  value       = helm_release.REPO.status
+}

--- a/templates/terraform/providers.tf
+++ b/templates/terraform/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+  }
+}
+
+# Cluster-agnostic: authenticates via kubeconfig, so any Kubernetes cluster
+# works (GKE, EKS, AKS, k3s, kind, minikube, ...).
+provider "helm" {
+  kubernetes {
+    config_path    = var.kubeconfig_path
+    config_context = var.kube_context
+  }
+}

--- a/templates/terraform/variables.tf
+++ b/templates/terraform/variables.tf
@@ -1,0 +1,17 @@
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to the kubeconfig used to reach the target cluster."
+  default     = "~/.kube/config"
+}
+
+variable "kube_context" {
+  type        = string
+  description = "Optional kubeconfig context to use (defaults to the current context)."
+  default     = null
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace to install into."
+  default     = "REPO"
+}

--- a/templates/terraform/variables.tf
+++ b/templates/terraform/variables.tf
@@ -15,3 +15,9 @@ variable "namespace" {
   description = "Namespace to install into."
   default     = "REPO"
 }
+
+variable "chart_values" {
+  type        = list(string)
+  description = "Extra values YAML documents applied to the release (highest precedence last)."
+  default     = []
+}


### PR DESCRIPTION
## Summary
Audit-round sync: new templates for everything the app repos now practice, plus SKILL.md accuracy/coverage fixes.

### Added templates
`Dockerfile.python`, per-context `dockerignore.{go,web,python}`, root `env.example`, **standard-form Helm chart skeleton** (`templates/helm/` + values example), **cluster-agnostic terraform** (`templates/terraform/` with `chart_values` passthrough).

### SKILL.md
Per-service internals standard (README/.gitignore/.dockerignore/.env.example per service); canonical Go module paths (`github.com/cuesoftinc/<repo>/api/common`); SSR-safety + 127.0.0.1-healthcheck gotchas; envoy-in-compose pattern; standard-form Helm/terraform deploy convention + hard-won chart gotchas (numeric `runAsUser`, bump chart version or the terraform helm provider won't upgrade local charts, `cuesoft` Docker Hub org); accuracy fixes (docs/ list, data stores, root-layout wording, `.dockerignore` parity scoping); PR template drops its CI reference (resynced byte-identically to all three repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
