### PR TITLE
Third pass: envFrom secret hook + Chart example in helm templates

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,7 +1,7 @@
-# CueLABS standard Makefile — compose-driven local development.
+# CueLABS standard Makefile — compose-driven local development + terraform deploy.
 # Run `make help` to list targets.
 .DEFAULT_GOAL := help
-.PHONY: help up down build rebuild logs ps restart clean
+.PHONY: help up down build rebuild logs ps restart clean tf-init tf-plan tf-apply tf-destroy
 
 help: ## List available targets
 	@grep -E '^[a-zA-Z_-]+:.*## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN{FS=":.*## "};{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
@@ -29,3 +29,15 @@ restart: ## Restart all services
 
 clean: ## Stop the stack and remove volumes + orphans
 	docker compose down -v --remove-orphans
+
+tf-init: ## Init terraform (deploy/terraform)
+	terraform -chdir=deploy/terraform init
+
+tf-plan: tf-init ## Preview the Kubernetes deployment
+	terraform -chdir=deploy/terraform plan
+
+tf-apply: tf-init ## Deploy the helm chart to the kubeconfig cluster
+	terraform -chdir=deploy/terraform apply
+
+tf-destroy: ## Tear down the deployed release
+	terraform -chdir=deploy/terraform destroy

--- a/templates/helm/Chart.example.yaml
+++ b/templates/helm/Chart.example.yaml
@@ -1,0 +1,9 @@
+# Copy to Chart.yaml and set name/description per repo. Bump `version` on every
+# chart change — the terraform helm provider will not upgrade a local chart
+# whose version is unchanged.
+apiVersion: v2
+name: REPO
+description: Deploys all services for REPO to Kubernetes.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -40,6 +40,13 @@ spec:
               value: {{ $v | quote }}
             {{- end }}
           {{- end }}
+          {{- with $svc.envFrom }}
+          envFrom:
+            {{- range . }}
+            - secretRef:
+                name: {{ .secretRef }}
+            {{- end }}
+          {{- end }}
           {{- if $svc.healthPath }}
           livenessProbe:
             httpGet:

--- a/templates/helm/values.example.yaml
+++ b/templates/helm/values.example.yaml
@@ -20,3 +20,7 @@ services:
     healthPath: /
     env:
       PORT: "3000"
+    # Inject secrets (JWT_SECRET, API keys, SMTP creds) from a Kubernetes Secret
+    # rather than plain env — create the Secret out of band, then:
+    # envFrom:
+    #   - secretRef: api-common-secrets


### PR DESCRIPTION
Keeps the canon Helm templates in lockstep with the three product repos after the third standardization pass.

- `templates/helm/templates/deployment.yaml`: optional `envFrom` secretRef hook (byte-identical with apparule/expendit/upstat).
- `templates/helm/values.example.yaml`: documents the secret-injection hook.
- `templates/helm/Chart.example.yaml`: copy-usable Chart.yaml skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)