### PR TITLE
docs: SKILL.md — X-10 identity/profile/KYC tier standard

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -271,6 +271,30 @@ flowchart LR
   tokens with `sign_in_provider != google.com`; UI ships exactly one
   "Continue with Google" CTA. Sandbox identity project: `sandbox-e306a`;
   `account.cuesoft.io` is a future facade over the same Firebase project.
+- Identity, profile & KYC tiers (X-10): layered on the auth standard above —
+  Google sign-in stays the sole credential; tiers add profile data and
+  verification, **never alternative logins**. **Tier 0 — Google identity**
+  (all products): firebase_uid + Google-verified email; grants all read/basic
+  use. **Tier 1 — self-attested profile & location** (captured in product
+  profile/settings; sensitive PII, never logged): apparule = bio + profile
+  location {city, state, country} powering proximity-ranked designer
+  recommendations and delivery-address pre-fill (the delivery address itself
+  stays frozen per order); expendit = tax-jurisdiction location
+  (state_of_residence for individuals, registered_address for company orgs)
+  which resolves the remittance authority (State IRS vs FIRS); upstat = org
+  timezone (IANA) only, for report rendering and time-bucketing —
+  deliberately the entire upstat requirement. **Tier 2 — provider-verified
+  financial identity** (only where money moves or government filings
+  generate): store provider refs + verification state, **never raw
+  government IDs** — apparule designer payouts = Paystack BVN-backed bank
+  resolution (the ecosystem pattern); expendit filing identity = TIN
+  (+ RC number + registered address for companies) gated at filing-pack
+  generation; upstat = N/A until billing enters the PRD. Rules: tiers gate
+  capabilities, never sign-in; KYC state machines + error codes live in flow
+  docs (apparule's kyc_incomplete/post_unavailable is the template); tier-2
+  fields are high-sensitivity in every data-model.md §4 classification;
+  verification is delegated to the money/filing provider — no in-house
+  document review.
 - Backends deploy to GCP Cloud Run (provisioned via the `cuesoft-iac` Pulumi
   ecosystem — never ad-hoc); frontends deploy to Firebase App Hosting; the
   Helm chart remains the self-host path.


### PR DESCRIPTION
## Summary

Adds the ratified cross-cutting **X-10 — Identity, profile & KYC tiers** standard (directive 2026-07-16) to `SKILL.md`'s Architecture conventions, as a bullet immediately after the X-1 auth standard — so new repos generated from this skill inherit a KYC posture instead of only apparule's ad-hoc A-2.

## What it standardizes

- **Tier 0 — Google identity** (all products): firebase_uid + Google-verified email; layered on X-1 — tiers add profile data and verification, never alternative logins.
- **Tier 1 — self-attested profile & location** (sensitive PII, never logged): apparule = bio + profile location for proximity-ranked recommendations and delivery pre-fill; expendit = tax-jurisdiction location (state_of_residence / registered_address) resolving the remittance authority; upstat = org timezone (IANA) only.
- **Tier 2 — provider-verified financial identity** (only where money moves or filings generate): provider refs + verification state only, **never raw government IDs** — apparule Paystack BVN-backed payouts (the ecosystem pattern); expendit TIN/RC gated at filing-pack generation; upstat N/A until billing.
- **Design rules**: tiers gate capabilities, never sign-in; KYC state machines + error codes live in flow docs; tier-2 fields are high-sensitivity in every data-model §4 classification; verification is delegated to providers — no in-house document review.

No other section of SKILL.md was restructured.

## Validation

- Architecture-conventions mermaid block re-validated with `@mermaid-js/mermaid-cli` (renders clean; edit is adjacent to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)