### PR TITLE
docs: SKILL.md — canonical web libraries

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -560,6 +560,14 @@ How each product's `web/` app is built (ratified 2026-07-18):
   (feature-scoped hooks/orchestration that own all state); views =
   `src/app/**` routes + composed components, render-only. **Views never
   fetch.**
+- **Canonical libraries (uniform across products, 2026-07-18)** —
+  interactive/behavior primitives use **Radix UI** (`@radix-ui/react-*`:
+  dialog, popover, select, switch, tooltip, tabs, checkbox, radio,
+  accordion); positioning-only cases may use Floating UI; the date library
+  is **date-fns** (never dayjs/moment in new code); class composition via
+  `clsx`; icons via `lucide-react` + inline brand SVGs. Known deviation:
+  upstat's W1 overlays are hand-rolled on Floating UI — converges to Radix
+  in its next web stage.
 - **Canonical routes (uniform across products, 2026-07-18)** — `/` is the
   public home; `/signin` is the ONLY auth route (never `/login`/`/signup`;
   legacy auth paths are quarantined or redirect to `/signin`); every


### PR DESCRIPTION
W1 parity audit found the last real divergence: apparule+expendit built interactive primitives on Radix while upstat hand-rolled overlays on Floating UI. Canon: Radix for behavior primitives, Floating UI for positioning-only, date-fns, clsx, lucide-react + inline brand SVGs. Upstat converges next stage (tracked deviation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)