### PR TITLE
docs(skill): real Discord channel names

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -744,7 +744,8 @@ URLs); `<Product>` = display name.
     `https://terms.cuesoft.io` · Status `https://status.cuesoft.io`.
 - **Legal bar** (verbatim, name substituted): `© Cuesoft Inc. 2026.
   <Product>. CueLABS™ Division. MIT License.` — "Cuesoft Inc." links to
-  `https://cuesoft.io`; "MIT License" links to
+  `https://cuesoft.io`; "CueLABS™ Division" links to
+  `https://cuelabs.cuesoft.io`; "MIT License" links to
   `https://github.com/cuesoftinc/<product>/blob/main/LICENSE`. The bar
   also carries a language selector (English-only for now; ships ahead of
   i18n by ratified decision 2026-07-19) and a security-policy affordance

--- a/SKILL.md
+++ b/SKILL.md
@@ -736,7 +736,10 @@ URLs); `<Product>` = display name.
   - *Community* (4): GitHub `https://github.com/cuesoftinc/<product>` ·
     Discord `https://discord.gg/CDfZxxrxbb` · Roadmap
     `https://cuesoft.gitbook.io/<product>/product/roadmap` · CueLABS
-    `https://cuelabs.cuesoft.io`.
+    `https://cuelabs.cuesoft.io`. Discord channel copy anywhere in the
+    product reads **`#<product>-lab`** (`#apparule-lab` / `#expendit-lab`
+    / `#upstat-lab` — the real channels on the CueLABS server; channel
+    names are never invented).
   - *Legal* (3): Privacy `https://privacy.cuesoft.io` · Terms
     `https://terms.cuesoft.io` · Status `https://status.cuesoft.io`.
 - **Legal bar** (verbatim, name substituted): `© Cuesoft Inc. 2026.


### PR DESCRIPTION
User correction 2026-07-19: product Discord channel copy reads #apparule-lab / #expendit-lab / #upstat-lab — the real channels on the CueLABS server. Invented names were an accuracy violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)