### PR TITLE
docs(skill): floating-layer viewport collision canon

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -598,7 +598,13 @@ How each product's `web/` app is built (ratified 2026-07-18):
   explicit rule gives v3 and v4 repos identical behavior. Clickable
   surfaces that aren't real buttons/links are a semantic-HTML violation,
   not a cursor problem.) An e2e asserts the computed cursor on a button
-  and a nav link.
+  and a nav link. **Floating layers collision-clamp (2026-07-19)**:
+  every popover/dropdown/menu/date-picker must stay fully within the
+  viewport at every breakpoint and anchor position (Radix layers get
+  `collisionPadding`/`align`; bespoke layers measure + clamp) — found
+  live as a period-picker popover clipping off the right screen edge.
+  e2e asserts an edge-anchored layer's boundingBox is inside the
+  viewport at 1440 and 390.
 - **Canonical routes (uniform across products, 2026-07-18)** — `/` is the
   public home; `/signin` is the ONLY auth route (never `/login`/`/signup`;
   legacy auth paths are quarantined or redirect to `/signin`); every


### PR DESCRIPTION
User-reported live bug 2026-07-19 (expendit period-picker popover clipping off the right screen edge) generalized to the class rule: every popover/dropdown/menu/date-picker stays fully within the viewport at every breakpoint and anchor position; e2e asserts boundingBox containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)