### PR TITLE
docs(templates): CueLABS™ in shared templates

### DIFF
--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing! This guide applies across CueLABS
+Thanks for your interest in contributing! This guide applies across CueLABS™
 repositories, which share a common structure and conventions.
 
 ## Getting started
@@ -12,7 +12,7 @@ repositories, which share a common structure and conventions.
 
 ## Repository layout
 
-CueLABS repositories follow a shared standard:
+CueLABS™ repositories follow a shared standard:
 
 - `api/common` — Go backend (auth + core API)
 - `api/<service>` — additional services, named by function

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,4 +1,4 @@
-# CueLABS standard Makefile — compose-driven local development + terraform deploy.
+# CueLABS™ standard Makefile — compose-driven local development + terraform deploy.
 # Run `make help` to list targets.
 .DEFAULT_GOAL := help
 .PHONY: help up down build rebuild logs ps restart clean tf-init tf-plan tf-apply tf-destroy


### PR DESCRIPTION
Brand-mark rule applied to the byte-parity template sources (Makefile, CONTRIBUTING.md) so repo copies and templates stay identical after the per-repo sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)