### PR TITLE
docs(skill): canonical web/src tree — shape is a parity item

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -571,6 +571,16 @@ How each product's `web/` app is built (ratified 2026-07-18):
   (feature-scoped hooks/orchestration that own all state); views =
   `src/app/**` routes + composed components, render-only. **Views never
   fetch.**
+- **Canonical `web/src/` tree (ratified 2026-07-21)** — exactly:
+  `app, auth, components, config, controllers, design, generated, lib,
+  mocks, models` (+ documented product-specific dirs, e.g. upstat
+  `proto/`). `mocks` is PLURAL; auth providers/context live in
+  `src/auth/` (not under controllers); env access goes through
+  `config/env.ts` typed accessors only; shared utils in `lib/`;
+  **no top-level modules in `src/`**. Tree SHAPE is a parity item:
+  standardization sweeps diff the directory trees across repos, not
+  just file contents/tooling — three shape drifts survived two months
+  because sweeps only compared contents (user-flagged 2026-07-21).
 - **Canonical libraries (uniform across products, 2026-07-18)** —
   interactive/behavior primitives use **Radix UI** (`@radix-ui/react-*`:
   dialog, popover, select, switch, tooltip, tabs, checkbox, radio,


### PR DESCRIPTION
Ratifies the exact web/src directory set (mocks plural, src/auth, config/env.ts, lib/, no top-level modules) and makes tree-shape diffing part of every standardization sweep. Fixes land via chore/tree-parity PRs ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)