### PR TITLE
docs(skill): changelog discipline

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -925,6 +925,14 @@ listed shared files are BYTE-IDENTICAL across repos — verify by shasum):
   nav rail's Link prefetch converges every dashboard route to one
   chunk union (navigation latency traded for lab bytes), and the
   framework floor is ~107K encoded.
+  **Changelog discipline (ratified 2026-07-21)**: Keep a Changelog
+  strictly — ONE `### <Bucket>` heading per bucket per section, in
+  canonical order (Added, Changed, Deprecated, Removed, Fixed,
+  Security). Top-ups MERGE entries into the existing bucket headings
+  under `[Unreleased]`, never append a second `### Changed` (five
+  duplicate heading sets accumulated across three repos before this
+  was caught — user-flagged). The standards repo's own CHANGELOG gets
+  an entry with every SKILL canon merge, same rules.
   **A11y closeout canons (ratified 2026-07-21, fleet)**: (1) every
   route ships a skip-to-content link — `components/ui/SkipLink.tsx`,
   first focusable in the root layout/shell, `href="#main"`, hidden


### PR DESCRIPTION
One bucket heading per section, canonical order, top-ups merge into existing buckets; standards CHANGELOG entries ride every canon merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)