### PR TITLE
docs(skill): mobile pin corrections (skeleton-wave verified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `SKILL.md` mobile standard: resolver-verified pin corrections from the
+  skeleton wave — riverpod_lint 3.x as a native analyzer plugin (custom_lint
+  retired), build_runner/freezed/intl caps, gen-l10n key removal,
+  go_router_builder public mixins, AGP 9 resValues default (#123).
+
 - `SKILL.md` mobile standard: legacy-quarantine rule — superseded code moves
   to `lib/legacy/` and is removed only after its replacement ships with an
   explicit user go (#121).

--- a/SKILL.md
+++ b/SKILL.md
@@ -1174,8 +1174,18 @@ org canon.
   FEATURE-FIRST: `lib/src/features/<feature>/{presentation,domain,data}`
   + `src/{app,routing,core}` — core/ui is the design system.
 - **State/DI**: Riverpod 3 with codegen (`@riverpod` ViewModels,
-  ConsumerWidgets; riverpod_lint via custom_lint). DI = Riverpod
-  provider overrides per environment — no second DI container.
+  ConsumerWidgets; riverpod_lint 3.x is a NATIVE analyzer plugin —
+  installed via analysis_options `plugins:`, diagnostics in plain
+  `flutter analyze`; custom_lint is retired for it and cannot
+  co-resolve with the modern codegen stack). DI = Riverpod provider
+  overrides per environment — no second DI container. Pin notes
+  (resolver-verified 2026-07-22): build_runner ≤2.15.1 with
+  riverpod_generator 4.0.4; freezed rides its analyzer-12 compat
+  release; intl pins exactly to the SDK's flutter_localizations;
+  gen-l10n's `synthetic-package` key is removed upstream;
+  go_router_builder 4.4 mixes in PUBLIC `$Route` mixins; AGP 9
+  defaults `buildFeatures.resValues` OFF (enable before flavor
+  resValue use).
 - **Navigation**: go_router + go_router_builder typed routes
   (accepted in maintenance mode — first-party; revisit on a successor);
   StatefulShellRoute for the tab shell; one top-level auth `redirect`


### PR DESCRIPTION
Resolver-verified on Flutter 3.44.7 during apparule#143: riverpod_lint 3.x is a native analyzer plugin (custom_lint retired), build_runner ≤2.15.1, freezed analyzer-12 compat build, intl SDK pin, gen-l10n synthetic-package removed, go_router_builder public mixins, AGP 9 resValues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)