### PR TITLE
docs(skill): mobile flavor model — dev + prod, sandbox is production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `SKILL.md` mobile standard: flavors mirror the org environment model —
+  `dev` + `prod` only (the sandbox account is CueLABS production); the
+  generic dev/stg/prd trio is rejected (#124).
+
 - `SKILL.md` mobile standard: resolver-verified pin corrections from the
   skeleton wave — riverpod_lint 3.x as a native analyzer plugin (custom_lint
   retired), build_runner/freezed/intl caps, gen-l10n key removal,

--- a/SKILL.md
+++ b/SKILL.md
@@ -1214,8 +1214,13 @@ org canon.
   discontinued; E2E = patrol smoke journeys, nightly not per-PR).
   CI: format check, codegen-fresh, analyze --fatal-infos + custom_lint,
   test --coverage with a gate, apk/ipa build matrix on main.
-- **Hygiene**: flavors dev/stg/prd (applicationIdSuffix + iOS schemes,
-  `appFlavor` constant, flavor-scoped assets); secrets via
+- **Hygiene**: flavors mirror the ORG ENVIRONMENT MODEL, not the
+  generic trio — CueLABS has one real environment (the sandbox account
+  IS production, user directive 2026-07-22), so mobile ships exactly
+  `dev` (fakes, ".dev" suffix) + `prod` (bare id, sandbox Firebase,
+  Doppler stg config); add flavors only when a ratified environment
+  exists (applicationIdSuffix + iOS schemes, `appFlavor` constant,
+  flavor-scoped assets); secrets via
   `--dart-define-from-file=env/<flavor>.json` generated from Doppler,
   gitignored — never envied/obfuscation as security; gen-l10n with
   `synthetic-package: false` (flutter_gen removed in current Flutter);


### PR DESCRIPTION
User directive (apparule M-7): the sandbox account is CueLABS production; flavors mirror the ratified environment model instead of the generic trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)