### PR TITLE
docs(skill): Linux-authored goldens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `SKILL.md` mobile standard: goldens are authored on Linux (alchemist CI
+  config normalizes text only; curve/gradient AA is platform-bound) via a
+  dockerized regen script or dispatch workflow; `url_launcher` joins the
+  pin ledger (#125).
+
 - `SKILL.md` mobile standard: flavors mirror the org environment model —
   `dev` + `prod` only (the sandbox account is CueLABS production); the
   generic dev/stg/prd trio is rejected (#124).

--- a/SKILL.md
+++ b/SKILL.md
@@ -1211,7 +1211,12 @@ org canon.
   inference/raw-types; tests mirror lib/src (unit = ViewModels/repos/
   services with mocktail + ProviderContainer overrides; widget = every
   screen over fakes; golden = alchemist — golden_toolkit is
-  discontinued; E2E = patrol smoke journeys, nightly not per-PR).
+  discontinued. GOLDENS ARE AUTHORED ON LINUX: alchemist's ci config
+  only platform-normalizes TEXT (obscured fonts); curve/gradient/
+  shadow anti-aliasing is platform-bound, so macOS-generated goldens
+  fail Linux CI with small deterministic diffs (~0.02–1.6%). Regenerate
+  via the repo's dockerized script or the mobile-goldens dispatch
+  workflow — never bump tolerances to paper over platform drift; E2E = patrol smoke journeys, nightly not per-PR).
   CI: format check, codegen-fresh, analyze --fatal-infos + custom_lint,
   test --coverage with a gate, apk/ipa build matrix on main.
 - **Hygiene**: flavors mirror the ORG ENVIRONMENT MODEL, not the


### PR DESCRIPTION
From apparule#147: alchemist's CI config normalizes text only; curve/gradient anti-aliasing is platform-bound — goldens regenerate in a Linux container (repo script / dispatch workflow), never via tolerance bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)