### PR TITLE
docs(skill): repeating-MI test canon — reduced-motion suites + painted draw progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `SKILL.md` mobile standard: the repeating-MI test canon — screens hosting
+  repeating MI primitives run their wiring suites and seeded goldens under
+  the platform reduced-motion flag (motion stays covered by the primitives'
+  bounded-pump unit tests), and animated size/draw progress inside
+  IntrinsicHeight rows is painted, never laid out (a fractional sizer at
+  factor 0 reports an infinite intrinsic and crashes the row) (#131).
+
 - `SKILL.md` mobile standard: the E2E lane canon (patrol journeys, nightly
   cadence, prove-then-revert for dispatch-only workflows) and the on-device
-  IME-injection gotcha (#131).
+  IME-injection gotcha (#132).
 
 - `SKILL.md` mobile standard: build-state hygiene at the gate — flutter
   clean, daemon stops, docker image prunes, and DerivedData purges are part

--- a/SKILL.md
+++ b/SKILL.md
@@ -1288,6 +1288,19 @@ org canon.
   fail Linux CI with small deterministic diffs (~0.02–1.6%). Regenerate
   via the repo's dockerized script or the mobile-goldens dispatch
   workflow — never bump tolerances to paper over platform drift; E2E = patrol smoke journeys, nightly not per-PR).
+  **Repeating-MI test canon (ratified 2026-07-23, apparule Lane B)**:
+  once a screen hosts a REPEATING MI primitive (pulse/typing/shimmer),
+  `pumpAndSettle` never terminates on it — wiring/transition suites and
+  seeded screen goldens for such screens run under the platform
+  reduced-motion flag (`FakeAccessibilityFeatures(disableAnimations:
+  true)` / a `disableAnimations` MediaQuery wrapper), which every MI
+  primitive must honor per design.md §5 (same anatomy, static); the
+  MOTION itself is covered by the primitive's own bounded-pump unit
+  tests. Corollary: animated size/draw progress inside
+  IntrinsicHeight-measured rows must be PAINTED, never laid out — a
+  FractionallySizedBox at heightFactor 0 reports an infinite max
+  intrinsic (child ÷ 0) and crashes the row on frame one (found live:
+  the MI-14 connector draw inside the C8 timeline rows).
   CI: format check, codegen-fresh, analyze --fatal-infos + custom_lint,
   test --coverage with a gate, apk/ipa build matrix on main.
 - **Hygiene**: flavors mirror the ORG ENVIRONMENT MODEL, not the


### PR DESCRIPTION
## Summary
- Adds the repeating-MI test canon to the mobile Quality standard (ratified 2026-07-23, apparule Lane B): screens hosting repeating MI primitives run wiring/transition suites and seeded goldens under the platform reduced-motion flag (`FakeAccessibilityFeatures(disableAnimations: true)` / a `disableAnimations` MediaQuery wrapper) — `pumpAndSettle` can never terminate against a repeating pulse; the motion itself stays covered by each primitive's bounded-pump unit tests.
- Corollary canon: animated size/draw progress inside IntrinsicHeight-measured rows must be PAINTED, never laid out — a `FractionallySizedBox` at `heightFactor: 0` reports an infinite max intrinsic height (child ÷ 0) and crashes the row on frame one. Found live when the C8 order timeline adopted `TimelineConnector` (cuesoftinc/apparule Lane B).
- CHANGELOG entry merged into the existing `### Added` bucket per the changelog discipline.

## Test plan
- [x] Docs-only; canon verified live in cuesoftinc/apparule (Lane B PR): reduced-motion suites settle, IntrinsicHeight regression test added to the primitive's suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)