### PR TITLE
docs(skill): Go versions row reconciled to the 1.26 single-truth canon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `SKILL.md`: the Recommended-versions Go row reconciled to the Go
+  single-truth canon — 1.26 fleet-wide with `golang:1.26-alpine`
+  (the row still framed apparule as a lone 1.26 exception; caught by
+  the pass-3 sweep) (#134).
+
 - `SKILL.md` self-consistency pass (found by the standards self-audit):
   the pre-canon Flutter tree block now points at the feature-first mobile
   standard; mobile CI described as it ships (native riverpod_lint on

--- a/SKILL.md
+++ b/SKILL.md
@@ -1431,7 +1431,7 @@ Keep current; last reviewed with the values below.
 | Area | Version |
 |------|---------|
 | Next.js / React / TypeScript | 16.x / 19.2 / 5.9 |
-| Go | 1.25+ — builder image matches the module's `go` directive (`golang:1.25-alpine`; apparule is on 1.26) |
+| Go | 1.26 fleet-wide (single-truth canon) — builder image matches the module's `go` directive (`golang:1.26-alpine`) |
 | Gin | v1.12 |
 | Node | 24 (`node:24-slim` images) |
 | Android (Kotlin / Gradle / compileSdk) | 2.2 / 9.1 / 36 — for future native apps |


### PR DESCRIPTION
Pass-3 sweep catch: SKILL.md:1434 still said Go 1.25+ with golang:1.25-alpine and framed apparule as the lone 1.26 exception — contradicting the #133 Go single-truth canon and verified reality (all three products on 1.26). Row reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)