### PR TITLE
fix: seed .env.example without drift checks + release hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-07-23
+
+### Fixed
+
+- Audit: the root `.env.example` is seeded, never byte-compared — the canon
+  fixes its variable names and section format while values and
+  product-specific sections diverge per repository, so customization no
+  longer reads as shared-file drift (which kept every adopter at
+  "Baseline conforming: no").
+- The repository's own `SECURITY.md` now carries the published reporting
+  policy (private vulnerability reporting, dedicated security mailbox).
+- Changelog cut into released sections — v2.0.0 shipped with all entries
+  still under Unreleased; adoption docs now also state that the catalog
+  repository itself is not a manifest-carrying adopter.
+
+## [2.0.0] - 2026-07-23
+
 ### Added
 
 - Multi-skill v2 catalog with focused repository, web, mobile, delivery, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   fixes its variable names and section format while values and
   product-specific sections diverge per repository, so customization no
   longer reads as shared-file drift (which kept every adopter at
-  "Baseline conforming: no").
+  "Baseline conforming: no") (#138).
 - The repository's own `SECURITY.md` now carries the published reporting
-  policy (private vulnerability reporting, dedicated security mailbox).
+  policy (private vulnerability reporting, dedicated security mailbox) (#138).
 - Changelog cut into released sections — v2.0.0 shipped with all entries
   still under Unreleased; adoption docs now also state that the catalog
-  repository itself is not a manifest-carrying adopter.
+  repository itself is not a manifest-carrying adopter (#138).
 
 ## [2.0.0] - 2026-07-23
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,11 @@ expected to track `main`.
 
 Report privately using GitHub's
 [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
-(the **Security → Report a vulnerability** tab), or email the maintainers listed
-in CODEOWNERS.
+through the repository's **Security → Report a vulnerability** tab. CueLABS™
+public repositories must enable private vulnerability reporting before
+publishing this policy. If that tab is unavailable, email `security@cuesoft.io`
+with the subject `Security vulnerability: <repository name>`. Do not disclose
+the vulnerability in an issue, discussion, or pull request.
 
 Please include a description and impact, steps to reproduce, and the affected
 component. We aim to acknowledge within 3 business days.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -40,6 +40,11 @@ gh skill install cuesoftinc/oss-engineering-standards \
 
 ## Add the project manifest
 
+The manifest belongs to adopter repositories. This catalog repository is the
+canon source, not an adopter — it carries no `.cuelabs/project.yaml`, and its
+repository files (a documentation-repo `.gitignore`, catalog-specific
+contributing and PR-template content) are intentionally not template-identical.
+
 Copy the example:
 
 ```bash

--- a/skills/cuelabs-engineering-standards/scripts/cuelabs_standard.py
+++ b/skills/cuelabs-engineering-standards/scripts/cuelabs_standard.py
@@ -43,6 +43,11 @@ CUELABS_APPLICATION_TEMPLATE_TARGETS = {
     "env.example": ".env.example",
 }
 
+# Seeded targets are copied when missing but never byte-compared afterwards:
+# the canon fixes their variable NAMES and section format, while values and
+# product-specific sections legitimately diverge per repository.
+SEEDED_TEMPLATE_SOURCES = {"env.example"}
+
 PORTABLE_REPOSITORY_FILES = [
     "CODEOWNERS",
     "CODE_OF_CONDUCT.md",
@@ -805,7 +810,10 @@ def inspect(repo: Path) -> Audit:
         source = TEMPLATE_ROOT / source_name
         if not source.is_file():
             collisions.append(f"{destination_name} (bundled template missing)")
-        elif destination.read_bytes() != source.read_bytes():
+        elif (
+            source_name not in SEEDED_TEMPLATE_SOURCES
+            and destination.read_bytes() != source.read_bytes()
+        ):
             drifted_shared.append(destination_name)
 
     repository_specific = ["README.md", "CHANGELOG.md"]

--- a/tests/test_cuelabs_standard.py
+++ b/tests/test_cuelabs_standard.py
@@ -91,6 +91,29 @@ class StandardsCliTest(unittest.TestCase):
         self.assertIn("LICENSE", audit.drifted_shared_files)
         self.assertFalse(audit.conforming)
 
+    def test_customized_env_example_is_seeded_not_drift(self) -> None:
+        self.write_manifest("  web: active\n")
+        self.copy_required_templates(application=True)
+        (self.repo / ".env.example").write_text(
+            "# product local development environment.\nJWT_SECRET=dev-only\n"
+        )
+        (self.repo / ".github").mkdir(exist_ok=True)
+        (self.repo / ".github" / "dependabot.yml").write_text("version: 2\n")
+
+        audit = standard.inspect(self.repo)
+
+        self.assertNotIn(".env.example", audit.drifted_shared_files)
+        self.assertTrue(audit.conforming)
+
+    def test_missing_env_example_is_still_seeded_on_apply(self) -> None:
+        self.write_manifest("  web: active\n")
+        self.copy_required_templates(application=True)
+        (self.repo / ".env.example").unlink()
+
+        audit = standard.inspect(self.repo)
+
+        self.assertIn(".env.example", audit.missing_shared_files)
+
     def test_invalid_manifest_is_rejected(self) -> None:
         manifest = self.repo / ".cuelabs" / "project.yaml"
         manifest.parent.mkdir()


### PR DESCRIPTION
## Summary

- audit: root `.env.example` becomes a **seeded** target — copied when missing, never byte-compared (canon fixes variable names/section format; values and product sections diverge per repo). Every adopter previously audited "Baseline conforming: no" on legitimate env content.
- two regression tests: customized env is not drift (full conformance), missing env is still seeded.
- syncs this repo's own `SECURITY.md` to the published policy template.
- cuts the changelog into released sections (`[2.0.0]` was shipped entirely under Unreleased) and stages a `[2.0.1]` section.
- adoption docs: the catalog repository itself is not a manifest-carrying adopter.

## Validation

- `python3 scripts/validate_catalog.py` — 5 skills
- `python3 -m unittest discover -s tests` — OK (incl. 2 new tests)
- live fleet audits: apparule/expendit/upstat now "Baseline conforming: yes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)